### PR TITLE
Allow click override exclusion on elements via optional class name regex

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@
 		scm = current.getAttribute('src').replace(/script\.js.*/g,'scm.html?03022013')+'#'+dest,
 		scmHost = scm[0] == '/' ? destHost : scm.substr(0,scm.indexOf('/',10)),
 		isOutside = !hasFrame || location.href.indexOf("scmplayer=true")>0,
-		exclude = new RegExp(current.getAttribute('data-exclude') || 'ajax');
+		exclude = new RegExp(current.getAttribute('data-exclude') || 'ajax'),
 		postMessage = function(msg){
 			return window.top.document.getElementById('scmframe')
 				.contentWindow.postMessage(msg,scmHost);


### PR DESCRIPTION
Some links have their own AJAX handlers, we don't want to add additional click handler behaviour on top.

By setting `<script data-exclude="(ajax|leavemealone)">...` or using the default `/ajax/` class SCM won't handle the click on those elements.

Real world scenario: django-endless-pagination uses `.endless_more` for pagination
