### PR TITLE
Fix for Soundcloud playlist resolver Forbidden HTTP Status

### DIFF
--- a/js/playlist/soundcloud.js
+++ b/js/playlist/soundcloud.js
@@ -28,7 +28,7 @@ define(['jquery','song'],function($,Song){
 
 	return {
 		load:function(url, req, callback, config){
-			// Soundcloud returns a 401 Unauthorized if a consumer key is not provided as at 2015-01-21
+			// Soundcloud may return a 401 Unauthorized if a consumer key is not provided
 			load('http://api.soundcloud.com/resolve?consumer_key=' + consumer_key + '&url=' + url,callback);
 		}
 	}

--- a/js/playlist/soundcloud.js
+++ b/js/playlist/soundcloud.js
@@ -28,7 +28,8 @@ define(['jquery','song'],function($,Song){
 
 	return {
 		load:function(url, req, callback, config){
-			load('http://api.soundcloud.com/resolve?url=' + url,callback);
+			// Soundcloud returns a 401 Unauthorized if a consumer key is not provided as at 2015-01-21
+			load('http://api.soundcloud.com/resolve?consumer_key=' + consumer_key + '&url=' + url,callback);
 		}
 	}
 });


### PR DESCRIPTION
Soundcloud may reject requests to resolve a playlist by URL, adding one's consumer key seems to fix it.

```
$ curl http://api.soundcloud.com/resolve?url=https://soundcloud.com/ministryofsound/house-party-minimix
{"errors":[{"error_message":"401 - Unauthorized"}]}
```

Performing the same with the ``consumer_key`` as the first GET param returns the desired response.

@Aramgutang: could you please review?