### PR TITLE
Allow playlist render if a track is no longer streamable

### DIFF
--- a/js/playlist/soundcloud.js
+++ b/js/playlist/soundcloud.js
@@ -16,6 +16,9 @@ define(['jquery','song'],function($,Song){
 		},
 		done = function(data,callback){
 			callback($.map(data,function(track){
+				if (!track.streamable) {  // Sometimes tracks get pulled
+					return new Song({});  // Return a blank, avoids adding to Playlist
+				}
 				var url = track.stream_url;
 				url += url.match(/[a-z]*\?/i) ? '&':'?';
 				url += 'consumer_key=' + consumer_key;


### PR DESCRIPTION
Allows streamable tracks to be rendered as normal.

Example: https://api.soundcloud.com/tracks/151776364 (add `consumer_key` when `curl`'ing) "Two Tone Melody" exists in MC's playlist but is no longer streamable. When line 23 tries to `.match()` there is no `stream_url` present in the JSON response, throwing an exception that prevents the playlist from rendering.

@Aramgutang: could you please review?
